### PR TITLE
Webpack: elm types reloading in watch mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: node_js
 node_js:
   - '8'
 
+cache: yarn
+
 matrix:
   include:
     - os: osx
     - os: linux
 
-cache: yarn
+script:
+  - npm run build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,3 +15,6 @@ install:
 build: off
 version: '{build}'
 shallow_clone: true
+
+test_script:
+  - yarn build

--- a/elm-types-webpack-plugin.js
+++ b/elm-types-webpack-plugin.js
@@ -13,17 +13,20 @@ module.exports = class ElmTypesPlugin {
     return path.join(this.outputPath, `${elmModuleName}.elm`);
   }
 
-  apply(compiler) {
-    compiler.plugin('run', (compiler, callback) => {
-      console.log('Generate Elm type from typescript interfaces...');
-      convert(this.inputFile, this.outputFile, (err) => {
-        if (err) {
-          console.error('Error while generating Elm types', err);
-        } else {
-          console.log('Generation successful!');
-          callback();
-        }
-      });
+  build(compiler, callback) {
+    console.log('Generate Elm type from typescript interfaces...');
+    convert(this.inputFile, this.outputFile, (err) => {
+      if (err) {
+        console.error('Error while generating Elm types', err);
+      } else {
+        console.log('Generation successful!');
+        callback();
+      }
     });
+  }
+
+  apply(compiler) {
+    compiler.plugin('run', this.build.bind(this));
+    compiler.plugin('emit', this.build.bind(this));
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ElmTypesPlugin = require('./elm-types-webpack-plugin');
+const WatchIgnorePlugin = require("webpack").WatchIgnorePlugin;
 
 const excludeFolders = [
   /elm-stuff/,
@@ -59,6 +60,9 @@ module.exports = [
     entry: { renderer: path.join(__dirname, 'src', 'static', 'renderer.ts') },
     target: 'electron-renderer',
     plugins: [
+      new WatchIgnorePlugin([
+        path.resolve(__dirname, './src/elm/TsElmInterfaces.elm'),
+      ]),
       new HtmlWebpackPlugin({
         title: 'Broxy',
       }),


### PR DESCRIPTION
It is still not perfect:
* webpack does not trigger plugin `run` step in watch mode
* `emit` steps is triggered after the Elm loader

That results in `yarn run watch` fails being called for the first time - it works after restart.

